### PR TITLE
Add bison (required to compile drake)

### DIFF
--- a/install_prereqs.sh
+++ b/install_prereqs.sh
@@ -4,7 +4,7 @@ case $1 in
   ("homebrew")
     brew install cmake pcre ;;
   ("ubuntu")
-    apt-get install cmake build-essential yodl ;;
+    apt-get install cmake build-essential yodl bison ;;
   (*)
     echo "Usage: ./install_prereqs.sh package_manager"
     echo "where package_manager is one of the following: "


### PR DESCRIPTION
Compilation of drake distro is failing on my system with

```
The SWIG test-suite and examples are configured for the following languages:
java lua matlab perl5 python ruby tcl 

[ 37%] Performing build step for 'swig-matlab'
/home/wxm/dev/drake/externals/swig_matlab/swig-matlab/Tools/config/ylwrap: line 176: yacc: command not found
make[9]: *** [CParse/parser.c] Error 127
make[8]: *** [source] Error 2
make[7]: *** [swig-matlab-prefix/src/swig-matlab-stamp/swig-matlab-build] Error 2
make[6]: *** [CMakeFiles/swig-matlab.dir/all] Error 2
make[5]: *** [CMakeFiles/install.dir/rule] Error 2
make[4]: *** [install] Error 2
make[3]: *** [swig_matlab-prefix/src/swig_matlab-stamp/swig_matlab-build] Error 2
make[2]: *** [CMakeFiles/swig_matlab.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 2
```

Turns out I didn't have `bison` installed (@tkoolen diagnosed it as only being a pre-req for a private external). This adds bison to the pre-reqs for swig-matlab.
